### PR TITLE
Release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2025-12-26
+
 ### Changed
 - Refactor: Extracted shared video playback logic into `playVideo` helper (#42)
   - Consolidated duplicate code from PlayerControls and useMediaControls
@@ -86,6 +88,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Queue and history management
 - Basic video player controls
 
+[0.3.2]: https://github.com/zalun/karaoke-app/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/zalun/karaoke-app/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/zalun/karaoke-app/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/zalun/karaoke-app/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/zalun/karaoke-app/compare/v0.1.0...v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "karaoke-app",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "karaoke-app"
-version = "0.3.1"
+version = "0.3.2"
 description = "Home karaoke application for macOS"
 authors = ["Piotr Zalewa"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Karaoke",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "app.karaoke.home",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Bump version to 0.3.2
- Update CHANGELOG.md with release notes

## Changes in 0.3.2

### Changed
- Refactor: Extracted shared video playback logic into `playVideo` helper (#42)

### Fixed
- Media controls event polling thread now shuts down gracefully on app exit (#40)

Closes #49

## After merge
Create and push tag:
```bash
git tag v0.3.2
git push origin v0.3.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)