### PR TITLE
Fix queue not continuing after playing from History or Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated all command modules: display, queue, session, keep_awake, media_controls, youtube
 
 ### Fixed
+- Fix queue not continuing after playing from History or Search (#68)
+  - Songs played from Search or History no longer cause auto-play to continue through history
+  - When a song ends naturally, the next song always comes from the queue
+  - "Next" button still navigates forward through history as expected
 - Fix window restoring to wrong display and size (#60)
   - Use Tauri's monitor API for consistent physical pixel coordinates
   - Previously used CoreGraphics logical points which don't match window positions on Retina displays

--- a/src/components/player/VideoPlayer.tsx
+++ b/src/components/player/VideoPlayer.tsx
@@ -246,8 +246,11 @@ export function VideoPlayer() {
 
   const handleEnded = useCallback(async () => {
     log.info("Video ended");
-    const { playNext } = useQueueStore.getState();
-    const nextItem = playNext();
+    // Use playNextFromQueue to always take from queue when song ends naturally.
+    // This ensures songs played from Search or History don't cause the player
+    // to continue through history - it always goes to the queue next.
+    const { playNextFromQueue } = useQueueStore.getState();
+    const nextItem = playNextFromQueue();
 
     if (nextItem && nextItem.video.youtubeId) {
       // Play next from queue


### PR DESCRIPTION
## Summary
- Fixes bug where auto-play would continue through history instead of taking from queue
- When a song ends naturally, the next song now always comes from the queue
- The "Next" button still allows navigating forward through history

## Problem
When playing a song from Search or by clicking "Previous" to go back in History, the `historyIndex` would be set to a specific position. When the song ended, `playNext()` would check for more items ahead in history and play those instead of taking from the queue.

## Solution
- Add `playNextFromQueue()` that always takes from queue, ignoring history position
- Use `playNextFromQueue()` in `handleEnded` for auto-play when song ends
- Keep `playNext()` unchanged for the "Next" button, preserving history navigation

## Test plan
- [ ] Play a song from Search with items in queue → when it ends, next song should be from queue
- [ ] Click "Previous" to play a song from History with items in queue → when it ends, next song should be from queue
- [ ] Click "Next" button after going back in history → should navigate forward through history
- [ ] Queue should work normally when playing from queue

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)