### PR TITLE
Add explicit Play button to queue items (#70)

### DIFF
--- a/src/components/queue/DraggableQueueItem.tsx
+++ b/src/components/queue/DraggableQueueItem.tsx
@@ -105,6 +105,7 @@ export function DraggableQueueItem({
           onPlay();
         }}
         className="text-gray-400 hover:text-green-400 text-sm px-1"
+        aria-label="Play now"
         title="Play now"
       >
         ▶


### PR DESCRIPTION
## Summary

- Remove auto-play on click from queue item tiles to prevent accidental interruptions
- Add explicit Play button (▶) with green hover state next to Remove button
- Makes play action intentional and improves drag-and-drop reliability

## Test plan

- [ ] Click on queue item tile - should NOT start playback
- [ ] Click Play button (▶) - should move song to top and start playing
- [ ] Drag and drop queue items - should work without triggering play
- [ ] Remove button still works as expected

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)