### PR TITLE
Release version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-12-28
+
 ### Added
 - Reload button in PlayerControls for stuck videos (#69)
   - Re-fetches streaming URL and reloads video from the beginning
@@ -156,6 +158,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Queue and history management
 - Basic video player controls
 
+[0.4.0]: https://github.com/zalun/karaoke-app/compare/v0.3.5...v0.4.0
+[0.3.5]: https://github.com/zalun/karaoke-app/compare/v0.3.4...v0.3.5
+[0.3.4]: https://github.com/zalun/karaoke-app/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/zalun/karaoke-app/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/zalun/karaoke-app/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/zalun/karaoke-app/compare/v0.3.0...v0.3.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karaoke-app",
-  "version": "0.2.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karaoke-app",
-      "version": "0.2.1",
+      "version": "0.4.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "karaoke-app",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "karaoke-app"
-version = "0.3.5"
+version = "0.4.0"
 description = "Home karaoke application for macOS"
 authors = ["Piotr Zalewa"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Karaoke",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "identifier": "app.karaoke.home",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Bump version to 0.4.0 in all configuration files
- Update CHANGELOG.md with release notes

## Changes in 0.4.0

### Added
- Reload button in PlayerControls for stuck videos (#69)
- "Play Next" button in search results (#72)

### Changed
- Improved About dialog with description and GitHub link (#65)
- Use thiserror for structured error types in Rust backend (#57)

### Fixed
- Associate existing queue/history with newly started session (#77)
- Fix song duration display not updating in detached mode (#71)
- Fix queue not continuing after playing from History or Search (#68)
- Fix window restoring to wrong display and size (#60)

## Test plan
- [ ] Verify version shows 0.4.0 in About dialog
- [ ] Run `npm run tauri build` to ensure build succeeds

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)