### PR TITLE
Fix video playback on Fedora Linux (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix video playback not working on Fedora Linux (#93)
+  - Add GStreamer codec plugin dependencies for Linux packages
+  - RPM: gstreamer1-plugins-base, gstreamer1-plugins-good, gstreamer1-libav
+  - DEB: gstreamer1.0-plugins-base, gstreamer1.0-plugins-good, gstreamer1.0-libav
+  - Prefer H.264 (avc) codec and exclude HLS streams for WebKitGTK compatibility
+
 ### Added
 - Singer Favorites feature (#88)
   - Persistent singers can save favorite songs

--- a/src-tauri/src/services/ytdlp.rs
+++ b/src-tauri/src/services/ytdlp.rs
@@ -303,10 +303,13 @@ impl YtDlpService {
 
         let url = format!("https://www.youtube.com/watch?v={}", video_id);
 
+        // Prefer H.264 (avc1) codec for best compatibility with WebKitGTK/GStreamer on Linux
+        // Exclude HLS (m3u8) streams - HTML5 video doesn't support HLS natively on WebKitGTK
+        // Format priority: best mp4 with H.264 (no HLS) > best mp4 (no HLS) > best (no HLS)
         let output = Command::new(get_ytdlp_command())
             .arg(&url)
             .arg("-f")
-            .arg("best[ext=mp4]/best")
+            .arg("best[ext=mp4][vcodec^=avc][protocol!*=m3u8]/best[ext=mp4][protocol!*=m3u8]/best[protocol!*=m3u8]/best")
             .arg("--get-url")
             .arg("--no-warnings")
             .env("PATH", get_expanded_path())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,10 +41,22 @@
     },
     "linux": {
       "deb": {
-        "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
+        "depends": [
+          "libwebkit2gtk-4.1-0",
+          "libgtk-3-0",
+          "gstreamer1.0-plugins-base",
+          "gstreamer1.0-plugins-good",
+          "gstreamer1.0-libav"
+        ]
       },
       "rpm": {
-        "depends": ["webkit2gtk4.1", "gtk3"]
+        "depends": [
+          "webkit2gtk4.1",
+          "gtk3",
+          "gstreamer1-plugins-base",
+          "gstreamer1-plugins-good",
+          "gstreamer1-libav"
+        ]
       }
     }
   }

--- a/src/components/player/VideoPlayer.tsx
+++ b/src/components/player/VideoPlayer.tsx
@@ -304,7 +304,27 @@ export function VideoPlayer() {
     };
   }, [isDetached]);
 
-  const handleError = useCallback(async () => {
+  const handleError = useCallback(async (event: React.SyntheticEvent<HTMLVideoElement>) => {
+    const video = event.currentTarget;
+    const mediaError = video.error;
+
+    // Log detailed error information
+    const errorCodes: Record<number, string> = {
+      1: "MEDIA_ERR_ABORTED - Fetching was aborted",
+      2: "MEDIA_ERR_NETWORK - Network error during download",
+      3: "MEDIA_ERR_DECODE - Error decoding media (codec issue)",
+      4: "MEDIA_ERR_SRC_NOT_SUPPORTED - Media format not supported",
+    };
+
+    const errorCode = mediaError?.code || 0;
+    const errorMessage = mediaError?.message || "Unknown error";
+    const errorDescription = errorCodes[errorCode] || `Unknown error code: ${errorCode}`;
+
+    log.error(`Video error: ${errorDescription}`);
+    log.error(`Error message: ${errorMessage}`);
+    log.error(`Video src: ${video.src?.substring(0, 100)}...`);
+    log.error(`Network state: ${video.networkState}, Ready state: ${video.readyState}`);
+
     // If we used a cached URL that might be stale, retry with fresh fetch
     if (usedCachedUrlRef.current && currentVideo?.youtubeId) {
       log.debug("Cached URL failed, retrying with fresh fetch");


### PR DESCRIPTION
## Summary
- Add GStreamer codec plugin dependencies for Linux packages (RPM and DEB)
- Exclude HLS streams in yt-dlp format selector - WebKitGTK doesn't support HLS natively
- Prefer H.264 (avc) codec for better compatibility across platforms
- Add detailed MediaError logging in VideoPlayer for easier debugging

## Root Cause
YouTube was returning HLS manifest URLs (`hls_playlist`), which HTML5 `<video>` elements don't support on WebKitGTK. The fix requests direct video streams instead.

## Test plan
- [x] Tested on Fedora in UTM - audio plays correctly (video rendering blocked by VM graphics limitation)
- [ ] Test on real Fedora hardware to confirm full playback
- [ ] Verify macOS playback still works

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)