### PR TITLE
Make notification duration vary by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Custom karaoke-themed background image for macOS DMG installer (#112)
 
+### Changed
+- Notification duration now varies by type (#111)
+  - Success: 3s, Info: 4s, Warning: 6s, Error: 8s
+
 ## [0.5.3-beta] - 2025-12-31
 
 ### Added

--- a/src/stores/notificationStore.ts
+++ b/src/stores/notificationStore.ts
@@ -3,8 +3,13 @@ import { createLogger } from "../services";
 
 const log = createLogger("NotificationStore");
 
-// Auto-hide timeout in milliseconds
-const AUTO_HIDE_TIMEOUT_MS = 4000;
+// Auto-hide timeouts in milliseconds by notification type
+const AUTO_HIDE_TIMEOUTS: Record<NotificationType, number> = {
+  success: 3000,
+  info: 4000,
+  warning: 6000,
+  error: 8000,
+};
 
 // Animation duration in milliseconds (must match CSS)
 const ANIMATION_DURATION_MS = 300;
@@ -86,7 +91,9 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
 
       // Reset auto-hide timer to give user more time
       clearAllTimeouts();
-      const currentId = get().current?.id;
+      const current = get().current;
+      const currentId = current?.id;
+      const currentTimeout = current ? AUTO_HIDE_TIMEOUTS[current.type] : AUTO_HIDE_TIMEOUTS.info;
       autoHideTimeoutId = setTimeout(() => {
         const state = get();
         if (state.isVisible && state.current?.id === currentId) {
@@ -97,7 +104,7 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
             }
           }, ANIMATION_DURATION_MS);
         }
-      }, AUTO_HIDE_TIMEOUT_MS);
+      }, currentTimeout);
       return;
     }
 
@@ -138,7 +145,7 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
           }
         }, ANIMATION_DURATION_MS);
       }
-    }, AUTO_HIDE_TIMEOUT_MS);
+    }, AUTO_HIDE_TIMEOUTS[notification.type]);
   },
 
   dismiss: () => {


### PR DESCRIPTION
## Summary

- Different notification types now have different auto-hide durations based on their importance
- success: 3s (quick confirmation)
- info: 4s (moderate read time)
- warning: 6s (user should notice and consider)
- error: 8s (user needs time to read and act)

## Test plan

- [ ] Trigger a success notification (e.g., add song to queue) - should disappear after 3s
- [ ] Trigger an info notification - should disappear after 4s
- [ ] Trigger a warning notification - should disappear after 6s
- [ ] Trigger an error notification - should disappear after 8s

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)