### PR TITLE
Fix DMG containing Contents folder instead of .app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,7 @@ jobs:
           # create-dmg expects a SOURCE FOLDER containing the items to put in the DMG
           # If we pass the .app directly, it copies its contents rather than the bundle
           STAGING_DIR=$(mktemp -d)
+          trap "rm -rf '$STAGING_DIR'" EXIT
           cp -R "$APP_PATH" "$STAGING_DIR/"
           echo "Staged app in: $STAGING_DIR"
 
@@ -128,9 +129,6 @@ jobs:
             --no-internet-enable \
             "$DMG_PATH" \
             "$STAGING_DIR"
-
-          # Cleanup staging directory
-          rm -rf "$STAGING_DIR"
 
           echo "path=$DMG_PATH" >> $GITHUB_OUTPUT
           echo "name=$DMG_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Fix `create-dmg` receiving `.app` path directly instead of a source folder
- Create staging directory, copy `.app` into it, pass staging dir to `create-dmg`
- Use dynamic `$APP_NAME` for `--icon` parameter instead of hardcoded value

## Root Cause
`create-dmg`'s last argument is a **source folder** containing items to include. When passed a `.app` path directly, it treats the bundle as a folder and copies its **contents** (the `Contents` directory) rather than the whole bundle.

## Test plan
- [ ] Merge and tag a new release
- [ ] Verify DMG contains `HomeKaraoke.app` bundle (not `Contents` folder)
- [ ] Verify app can be dragged to Applications and launched

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)