### PR TITLE
Fix reload button always being actionable when video is loading

### DIFF
--- a/src/components/player/PlayerControls.tsx
+++ b/src/components/player/PlayerControls.tsx
@@ -420,8 +420,16 @@ export function PlayerControls() {
       } else {
         // YouTube mode: clear and restore video to force player re-initialization
         setCurrentVideo(null);
-        // Use setTimeout to ensure React processes the null state before setting new video
+        // Small delay to ensure React processes the null state before setting new video
         await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Verify video hasn't changed during delay (user clicked Next/Previous)
+        const currentVideoId = getCurrentItem()?.video.youtubeId || usePlayerStore.getState().currentVideo?.youtubeId;
+        if (currentVideoId && currentVideoId !== videoToReload.youtubeId) {
+          log.info("Video changed during reload, aborting");
+          return;
+        }
+
         setCurrentVideo({ ...videoToReload });
       }
 


### PR DESCRIPTION
Fixes #128

## Problem
When a video gets stuck loading (e.g., after YouTube shows related videos grid), the reload button was disabled and not clickable.

## Root Cause
`canReload` only checked `currentQueueItem?.video.youtubeId`, but during certain state transitions, `currentQueueItem` could be null even though `currentVideo` in playerStore has the video info.

## Fix
1. **Enable reload button** - Now checks both `currentVideo` and `currentQueueItem` to determine if reload should be enabled
2. **Fall back to currentVideo** - `handleReload` now uses `currentVideo` from playerStore if `getCurrentItem()` returns null
3. **YouTube mode reload** - Forces player re-initialization by briefly clearing and restoring the video (50ms delay to ensure React processes the state change)

## Changes
- `canReload` now uses `currentVideo?.youtubeId || currentQueueItem?.video.youtubeId`
- `handleReload` falls back to `usePlayerStore.getState().currentVideo`
- YouTube mode uses clear/restore pattern instead of trying to load same videoId

🤖 Generated with [Claude Code](https://claude.com/claude-code)