### PR TITLE
Fix unused imports and deprecated shell().open() warning

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,6 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = ["protocol-asset"] }
-tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
@@ -29,6 +28,7 @@ tauri-plugin-log = "2"
 tauri-plugin-localhost = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-opener = "2"
 url = "2"
 urlencoding = "2"
 keepawake = "0.5"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,7 +19,7 @@
     "core:event:default",
     "core:webview:allow-create-webview-window",
     "log:default",
-    "shell:allow-open",
+    "opener:allow-reveal-item-in-dir",
     "dialog:default",
     {
       "identifier": "fs:allow-read-file",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use tauri::menu::{AboutMetadata, CheckMenuItem, Menu, MenuItemKind, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::{Emitter, Manager};
 use tauri_plugin_log::{Target, TargetKind};
-use tauri_plugin_shell::ShellExt;
+use tauri_plugin_opener::OpenerExt;
 
 pub struct AppState {
     pub db: Mutex<Database>,
@@ -226,7 +226,7 @@ pub fn run() {
     }
 
     builder
-        .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         // Configure logging with file + stdout + webview targets
@@ -628,8 +628,8 @@ pub fn run() {
                     let log_dir = &state.log_dir;
                     info!("Opening log directory: {:?}", log_dir);
 
-                    // Use Tauri's shell plugin for cross-platform file manager opening
-                    if let Err(e) = app.shell().open(log_dir.to_string_lossy(), None) {
+                    // Use Tauri's opener plugin for cross-platform file manager opening
+                    if let Err(e) = app.opener().reveal_item_in_dir(log_dir) {
                         log::error!("Failed to open log directory: {}", e);
                     }
                 }

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -9,12 +9,10 @@ pub mod media_controls;
 #[cfg(target_os = "macos")]
 pub mod display_watcher;
 
-pub use ffmpeg::FfmpegService;
 pub use library_scanner::{
     LibraryFolder, LibraryScanner, LibraryStats, LibraryVideo, ScanOptions, ScanResult,
 };
-pub use metadata_fetcher::{LyricsResult, MetadataFetcher, SongInfo};
-pub use ytdlp::{find_executable_in_path, get_expanded_path, YtDlpService};
+pub use ytdlp::{get_expanded_path, YtDlpService};
 
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 pub use media_controls::MediaControlsService;


### PR DESCRIPTION
## Summary

- Remove unused imports from `src/services/mod.rs` (`FfmpegService`, `LyricsResult`, `MetadataFetcher`, `SongInfo`, `find_executable_in_path`)
- Replace deprecated `tauri-plugin-shell` with `tauri-plugin-opener`
- Use `opener().reveal_item_in_dir()` instead of `shell().open()` for opening log directory

## Test plan

- [ ] Build succeeds with `cargo check` (no warnings from the targeted items)
- [ ] Open Logs menu item still works (opens log directory in file manager)

Fixes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)