### PR TITLE
Hide console window when spawning yt-dlp/ffmpeg on Windows

### DIFF
--- a/src-tauri/src/services/ffmpeg.rs
+++ b/src-tauri/src/services/ffmpeg.rs
@@ -9,7 +9,7 @@ use std::process::Stdio;
 use std::sync::OnceLock;
 use tokio::process::Command;
 
-use super::ytdlp::{get_expanded_path, find_executable_in_path};
+use super::ytdlp::{get_expanded_path, find_executable_in_path, CommandNoWindow};
 
 /// Thumbnail extraction width in pixels (height auto-calculated to maintain aspect ratio)
 const THUMBNAIL_WIDTH: u32 = 320;
@@ -75,6 +75,7 @@ impl FfmpegService {
             .env("PATH", get_expanded_path())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .no_window()
             .output()
             .await
             .ok()?;
@@ -116,6 +117,7 @@ impl FfmpegService {
             .env("PATH", get_expanded_path())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .no_window()
             .output()
             .await;
 
@@ -221,6 +223,7 @@ impl FfmpegService {
             .env("PATH", get_expanded_path())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .no_window()
             .output()
             .await
             .map_err(|e| format!("Failed to execute ffmpeg: {}", e))?;


### PR DESCRIPTION
## Summary

- Add `CommandNoWindow` trait extension that applies `CREATE_NO_WINDOW` flag on Windows
- Apply trait to all `Command::new()` usages in `ytdlp.rs` (4 locations) and `ffmpeg.rs` (3 locations)
- On non-Windows platforms, the trait method is a no-op

Fixes #150

## Test plan

- [ ] Verify code compiles on macOS/Linux (trait is no-op)
- [ ] Test on Windows to confirm console window no longer appears when spawning yt-dlp/ffmpeg

🤖 Generated with [Claude Code](https://claude.com/claude-code)