### PR TITLE
fix: inject Supabase env vars into release builds (#226)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,23 @@ jobs:
           # Clean up certificate file
           rm -f $CERTIFICATE_PATH
 
+      - name: Verify Supabase build secrets
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+        run: |
+          if [ -z "$VITE_SUPABASE_URL" ] || [ -z "$VITE_SUPABASE_ANON_KEY" ]; then
+            echo "::error::VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY repo secrets must be set. Without them hosted sessions break in the released build."
+            exit 1
+          fi
+
       - name: Build Tauri app (signed, not notarized)
         run: npm run tauri build -- --target ${{ matrix.target }}
         env:
           # Only signing identity - no APPLE_ID/PASSWORD means no notarization
           APPLE_SIGNING_IDENTITY: "Developer ID Application: Piotr Zalewa"
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
 
       - name: Install create-dmg
         run: brew install create-dmg
@@ -288,8 +300,21 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Verify Supabase build secrets
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+        run: |
+          if [ -z "$VITE_SUPABASE_URL" ] || [ -z "$VITE_SUPABASE_ANON_KEY" ]; then
+            echo "::error::VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY repo secrets must be set. Without them hosted sessions break in the released build."
+            exit 1
+          fi
+
       - name: Build Tauri app for Linux
         run: npm run tauri build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
 
       - name: Find built packages
         id: find-packages
@@ -393,8 +418,22 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Verify Supabase build secrets
+        shell: bash
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+        run: |
+          if [ -z "$VITE_SUPABASE_URL" ] || [ -z "$VITE_SUPABASE_ANON_KEY" ]; then
+            echo "::error::VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY repo secrets must be set. Without them hosted sessions break in the released build."
+            exit 1
+          fi
+
       - name: Build Tauri app for Windows
         run: npm run tauri build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
 
       - name: Find built packages
         id: find-packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Hosted sessions failing with "User not loaded. Please sign in again." in released builds (#226)
+  - Root cause: `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` were not passed to `npm run tauri build` in CI or in `scripts/build-and-release.sh`, so the Supabase client was never initialised in the shipped binary.
+  - CI and the local release script now require both variables and fail fast if either is missing.
+
 ## [0.8.0] - 2026-02-19
 
 ### Added

--- a/scripts/build-and-release.sh
+++ b/scripts/build-and-release.sh
@@ -5,9 +5,11 @@ trap 'echo "Error at line $LINENO: Command \"$BASH_COMMAND\" failed with exit co
 # Build, sign, notarize, and upload to GitHub release
 #
 # Required environment variables:
-#   APPLE_ID        - Apple Developer email
-#   APPLE_PASSWORD  - App-specific password from appleid.apple.com
-#   APPLE_TEAM_ID   - Team ID (e.g., DCXDSQYXM7)
+#   APPLE_ID                 - Apple Developer email
+#   APPLE_PASSWORD           - App-specific password from appleid.apple.com
+#   APPLE_TEAM_ID            - Team ID (e.g., DCXDSQYXM7)
+#   VITE_SUPABASE_URL        - Supabase project URL (baked into the frontend bundle)
+#   VITE_SUPABASE_ANON_KEY   - Supabase anonymous key (baked into the frontend bundle)
 #
 # Usage:
 #   ./scripts/build-and-release.sh v0.6.3
@@ -53,6 +55,20 @@ fi
 
 if [ -z "$APPLE_TEAM_ID" ]; then
     echo "Error: APPLE_TEAM_ID environment variable not set"
+    exit 1
+fi
+
+if [ -z "$VITE_SUPABASE_URL" ]; then
+    echo "Error: VITE_SUPABASE_URL environment variable not set"
+    echo "       This must be set so Supabase auth works in the built app."
+    echo "       Without it, hosted sessions will fail with 'User not loaded'."
+    exit 1
+fi
+
+if [ -z "$VITE_SUPABASE_ANON_KEY" ]; then
+    echo "Error: VITE_SUPABASE_ANON_KEY environment variable not set"
+    echo "       This must be set so Supabase auth works in the built app."
+    echo "       Without it, hosted sessions will fail with 'User not loaded'."
     exit 1
 fi
 


### PR DESCRIPTION
Fixes #226.

## Summary

- CI (`release.yml`) and the local `scripts/build-and-release.sh` now pass `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` to `npm run tauri build` on macOS, Linux, and Windows.
- Both jobs/scripts fail fast if either variable is missing, so we can't accidentally tag a release without Supabase config again.
- GitHub repo secrets `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` have been set.

## Why

Vite inlines `import.meta.env.VITE_*` at build time. The `v0.8.0` binary was built without these vars, so `isSupabaseConfigured()` returned `false` at runtime, `user` was never populated, and `hostSession()` threw `User not loaded. Please sign in again.` for every user on the released build.

Confirmed by `strings /Applications/HomeKaraoke.app/Contents/MacOS/homekaraoke | grep -i supabase` → zero matches.

## Test plan

- [ ] Merge, bump version to `v0.8.1`, tag, and let CI rebuild.
- [ ] Download the resulting DMG, install, sign in, click *Host Session* — should succeed (no "User not loaded" notification).
- [ ] As a sanity check, temporarily unset one of the secrets and verify CI fails at the "Verify Supabase build secrets" step (don't merge that).

## Follow-up

Long-term, the desktop app shouldn't depend on the Supabase JS SDK at all — profile and refresh could go through `homekaraoke.app/api/*`. Tracked separately (see issue body of #226).

🤖 Generated with [Claude Code](https://claude.com/claude-code)