### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-15
+
 ### Fixed
 - Hosted sessions failing with "User not loaded. Please sign in again." in released builds (#226)
   - Root cause: `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` were not passed to `npm run tauri build` in CI or in `scripts/build-and-release.sh`, so the Supabase client was never initialised in the shipped binary.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homekaraoke",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homekaraoke"
-version = "0.8.0"
+version = "0.8.1"
 description = "Home karaoke application"
 authors = ["Piotr Zalewa"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "HomeKaraoke",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "app.homekaraoke",
   "plugins": {
     "deep-link": {


### PR DESCRIPTION
Bumps version to 0.8.1 in package.json, Cargo.toml, tauri.conf.json, and CHANGELOG.

Ships the fix from #226 (Supabase env vars now injected at build time) so hosted sessions work for users who downloaded the official build.

## Test plan

- [ ] Merge.
- [ ] Tag \`v0.8.1\` from main — CI builds and publishes the release with Supabase env vars now passed.
- [ ] Download new DMG, install, sign in, *Host Session* succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)