### PR TITLE
feat: auto-accept guest song requests, on by default (#231)

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ status.json
 progress.txt
 .progress.txt
 
-# OpenSpec
-openspec/changes/
+# OpenSpec — ignore active in-flight changes, but track archived ones for PR review
+openspec/changes/*
+!openspec/changes/archive/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Auto-accept guest song requests (opt-in) (#231)
-  - New "Auto-accept guest requests" toggle in Settings → Queue & History
-  - When enabled, incoming remote requests skip the approval modal and are added directly to the queue with singer auto-assignment
+### Changed
+- Guest song requests are now auto-accepted by default (#231)
+  - Incoming remote requests skip the approval modal and are added directly to the queue with singer auto-assignment
   - Passive toast per accepted request ("<guest> added <song> to the queue")
-  - `Auto-accept: ON` badge shown in the Host Session modal as a visible reminder
+  - New "Auto-accept guest requests" toggle in Settings → Queue & History — turn off to restore manual approval
+  - When opted out, a `Manual approval: ON` badge appears in the Host Session modal as a visible reminder
 
 ## [0.8.1] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New "Auto-accept guest requests" toggle in Settings → Queue & History — turn off to restore manual approval
   - When opted out, a `Manual approval: ON` badge appears in the Host Session modal as a visible reminder
 
+### Added
+- OpenSpec-driven development workflow (#232)
+  - Workflow recorded in `CLAUDE.md` (issue → explore → propose → branch → apply → review-and-fix → e2e → archive → PR)
+  - First spec captured under `openspec/specs/hosted-session-requests/spec.md`
+  - `/opsx:{explore,propose,apply,archive}` slash commands and `openspec-*` skills checked in under `.claude/` so the workflow is reproducible for contributors
+  - Archived OpenSpec changes are tracked in git for PR review; in-flight changes remain ignored
+
 ## [0.8.1] - 2026-05-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Auto-accept guest song requests (opt-in) (#231)
+  - New "Auto-accept guest requests" toggle in Settings → Queue & History
+  - When enabled, incoming remote requests skip the approval modal and are added directly to the queue with singer auto-assignment
+  - Passive toast per accepted request ("<guest> added <song> to the queue")
+  - `Auto-accept: ON` badge shown in the Host Session modal as a visible reminder
+
 ## [0.8.1] - 2026-05-15
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Branch naming: `feature/<issue-number>-<description>` or `fix/<issue-number>-<description>`
 - **Avoid `git commit --amend`** - prefer separate commits for fixes/updates (easier to review)
 
+### Standard Workflow (OpenSpec-driven)
+
+For any non-trivial change, follow this sequence:
+
+0. **Create a GitHub issue** describing the problem/feature
+1. `/opsx:explore` — think through the problem, surface options, ground in the codebase
+2. `/opsx:propose` — generate `openspec/changes/<name>/{proposal,specs,tasks}.md`
+3. **Create the feature branch** from main: `feature/<issue#>-<slug>` or `fix/<issue#>-<slug>`
+4. `/opsx:apply <name>` — implement tasks; mark each `[x]` as done
+5. `/review-and-fix` — run PR-review-toolkit agents, fix until clean
+6. **E2E + manual tests** — `just e2e` and a manual smoke of the feature
+7. `/opsx:archive <name>` — move spec deltas into `openspec/specs/`, close the change
+8. **PR + merge** — open PR linked to the issue, get review, squash-merge
+
+Notes:
+- `openspec/changes/` is gitignored; specs are committed only after archive.
+- Trivial fixes (typos, dep bumps) can skip steps 1–2 and 7.
+
 ### Pre-Push Checklist
 
 Before pushing changes, **ask the user** if E2E tests should be run:

--- a/openspec/changes/archive/2026-05-17-auto-accept-guest-requests/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-17-auto-accept-guest-requests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/archive/2026-05-17-auto-accept-guest-requests/README.md
+++ b/openspec/changes/archive/2026-05-17-auto-accept-guest-requests/README.md
@@ -1,0 +1,3 @@
+# auto-accept-guest-requests
+
+Add opt-in app-wide setting that auto-accepts incoming guest song requests, bypassing the approval modal (#231)

--- a/openspec/changes/archive/2026-05-17-auto-accept-guest-requests/proposal.md
+++ b/openspec/changes/archive/2026-05-17-auto-accept-guest-requests/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+For typical home-karaoke hosting (small parties, family use), the song-request approval modal added in #211 is unnecessary friction — the host wants requests to land directly on the queue. Defaulting auto-accept ON matches the common case; hosts who genuinely need vetting can opt out via Settings.
+
+Refines #231 (originally framed as opt-in; flipped to opt-out per host UX feedback).
+
+## What Changes
+
+- New app-wide setting `auto_accept_guest_requests` (bool, **default `true`**), surfaced as a toggle on the **Queue** tab of `SettingsDialog`.
+- When the setting is `true` (default), the hosted-session polling loop bypasses the approval modal: incoming pending requests are routed through the existing `addRequestToQueueWithSinger` path (singer auto-assignment from #215 is preserved).
+- For each auto-accepted request, fire a passive toast `"<guest_name> added <song> to the queue"` via the existing `notificationStore`. No action button.
+- When the setting is `false` (host opted out), the existing approval flow from #211 is unchanged, AND `HostSessionModal` shows a small `Manual approval: ON` badge near the join code so the host has a visible reminder that requests need their action.
+- The default-on case shows no badge — it's the expected baseline.
+
+Out of scope for this change:
+- Rate-limiting / spam protection (issue #231 open question, deferred).
+- Undo affordance on the auto-accept toast.
+- Per-session override (setting is app-wide only).
+
+## Capabilities
+
+### New Capabilities
+
+- `hosted-session-requests`: behavior of the host-side handling of incoming guest song requests — both the manual-approval flow (existing, captured to lock current behavior) and the new auto-accept opt-in path.
+
+### Modified Capabilities
+
+(none — `openspec/specs/` is currently empty; this change establishes the first spec.)
+
+## Impact
+
+- **Frontend**
+  - `src/stores/settingsStore.ts` — new key in `SETTINGS_KEYS` / `SETTINGS_DEFAULTS`.
+  - `src/components/settings/SettingsDialog.tsx` — toggle on the Queue tab.
+  - `src/stores/sessionStore.ts` — branch in `refreshHostedSession` polling: when setting is on, call into existing approval logic for each pending request instead of firing the "new requests" notification.
+  - `src/components/session/HostSessionModal.tsx` — `Auto-accept: ON` badge.
+- **Backend (Tauri / Rust):** no changes — setting persistence already routes through existing `settings_set` / `settings_get` commands.
+- **Backend (homekaraoke.app):** no changes — same `/api/session/{id}/requests` endpoints; client-side decision only.
+- **Database:** no schema migration (settings are KV).
+- **Tests:** unit tests on sessionStore branch; E2E coverage TBD in design / tasks.

--- a/openspec/changes/archive/2026-05-17-auto-accept-guest-requests/specs/hosted-session-requests/spec.md
+++ b/openspec/changes/archive/2026-05-17-auto-accept-guest-requests/specs/hosted-session-requests/spec.md
@@ -1,9 +1,5 @@
-# hosted-session-requests Specification
+## ADDED Requirements
 
-## Purpose
-Defines how guest song requests received via the hosted-session API are routed to the local queue — covering the default auto-accept flow, the opt-out manual-approval flow (preserving the approval modal from #211), and the host-visible reminder UI shown only when the host has opted out of the default.
-
-## Requirements
 ### Requirement: Auto-accept is the default for incoming guest song requests
 
 The system SHALL expose an app-wide boolean setting `auto_accept_guest_requests`, **default `true`**, configurable from the **Queue** tab of `SettingsDialog`. When `true` (default), incoming pending guest song requests SHALL be added to the queue automatically without host approval.
@@ -47,4 +43,3 @@ When the host toggles `auto_accept_guest_requests` to `false`, incoming guest so
 - **WHEN** the host toggles `auto_accept_guest_requests` from `false` to `true` while a session is active
 - **THEN** subsequent pending requests SHALL be auto-routed to the queue per the default behaviour
 - **AND** any pending requests still in the approval modal at toggle time SHALL remain pending until the next poll picks them up
-

--- a/openspec/changes/archive/2026-05-17-auto-accept-guest-requests/tasks.md
+++ b/openspec/changes/archive/2026-05-17-auto-accept-guest-requests/tasks.md
@@ -1,0 +1,30 @@
+## 1. Settings
+
+- [x] 1.1 Add `AUTO_ACCEPT_GUEST_REQUESTS: "auto_accept_guest_requests"` to `SETTINGS_KEYS` and `false` to `SETTINGS_DEFAULTS` in `src/stores/settingsStore.ts`
+- [x] 1.2 Expose a typed getter/setter on `useSettingsStore` for the new key (covered by the existing generic `getSetting`/`setSetting` — no per-key wrapper needed per project convention)
+- [x] 1.3 Add toggle + helper copy to the Queue tab of `src/components/settings/SettingsDialog.tsx` ("Auto-accept guest requests" / "Skip approval — incoming requests go straight to the queue")
+
+## 2. Session store branch
+
+- [x] 2.1 In `refreshHostedSession` (src/stores/sessionStore.ts), read `auto_accept_guest_requests` when new pending requests are detected
+- [x] 2.2 When setting is `true`, call `loadPendingRequests` and route each request through `addRequestToQueueWithSinger` instead of firing the "new requests" notification
+- [x] 2.3 For each auto-accepted request, emit one `notify("info", "<guest_name> added <song> to the queue")` with no action
+- [x] 2.4 Preserve current behavior when the setting is `false`
+
+## 3. Host UI badge
+
+- [x] 3.1 Render an `Auto-accept: ON` badge near the join code in `HostSessionModal` when `auto_accept_guest_requests` is `true`
+- [x] 3.2 Ensure the badge reactively appears/disappears as the setting toggles during an active session (selector subscribes to `useSettingsStore`)
+
+## 4. Tests
+
+- [x] 4.1 Unit-test sessionStore branch: setting off → notification fires, request stays pending
+- [x] 4.2 Unit-test sessionStore branch: setting on → `addRequestToQueueWithSinger` called per pending request, passive toast emitted, modal not shown
+- [x] 4.3 Unit-test that flipping setting mid-session changes routing on the next poll
+- [x] 4.4 E2E (or component test) for SettingsDialog toggle persistence — covered by settingsStore key/default tests + existing generic settings persistence
+- [x] 4.5 E2E (or component test) for `Auto-accept: ON` badge visibility in `HostSessionModal`
+
+## 5. Docs
+
+- [x] 5.1 Add an entry to `CHANGELOG.md` under Unreleased
+- [x] 5.2 Mention the toggle in CLAUDE.md "Hosted Sessions" section if user-facing behavior shifts (optional) — skipped; behaviour additive, no convention change

--- a/openspec/specs/hosted-session-requests/spec.md
+++ b/openspec/specs/hosted-session-requests/spec.md
@@ -1,0 +1,49 @@
+# hosted-session-requests Specification
+
+## Purpose
+TBD - created by archiving change auto-accept-guest-requests. Update Purpose after archive.
+## Requirements
+### Requirement: Auto-accept is the default for incoming guest song requests
+
+The system SHALL expose an app-wide boolean setting `auto_accept_guest_requests`, **default `true`**, configurable from the **Queue** tab of `SettingsDialog`. When `true` (default), incoming pending guest song requests SHALL be added to the queue automatically without host approval.
+
+#### Scenario: Toggle is visible and persistent in settings
+- **WHEN** the host opens `SettingsDialog` and selects the Queue tab
+- **THEN** the system SHALL display a toggle labelled "Auto-accept guest requests", on by default, with helper copy explaining that turning it off restores manual approval
+- **AND** changes to the toggle SHALL persist across app restarts via the existing settings store
+
+#### Scenario: Auto-accept routes new request directly to the queue
+- **WHEN** the hosted-session polling cycle detects a new pending request
+- **AND** the `auto_accept_guest_requests` setting is `true`
+- **THEN** the system SHALL invoke `addRequestToQueueWithSinger` for that request, adding the song to the queue and auto-assigning the singer
+- **AND** the request SHALL NOT appear in the approval modal
+
+#### Scenario: Auto-accept emits a passive toast per accepted request
+- **WHEN** a request is auto-accepted
+- **THEN** the system SHALL emit one notification containing the guest's name and the song title (e.g. `"<guest_name> added <song> to the queue"`)
+- **AND** the notification SHALL NOT include an action button
+
+### Requirement: Host can opt out into manual approval
+
+When the host toggles `auto_accept_guest_requests` to `false`, incoming guest song requests SHALL be held for manual approval (preserving the flow from #211) and the host SHALL get a visible reminder that the non-default mode is active.
+
+#### Scenario: New pending requests arrive while auto-accept is off
+- **WHEN** the hosted-session polling cycle detects one or more new pending requests
+- **AND** the `auto_accept_guest_requests` setting is `false`
+- **THEN** the system SHALL display a notification reporting the new request count with a "View" action
+- **AND** the requests SHALL remain in `pending` status until the host approves or rejects them
+
+#### Scenario: Host approves a pending request via the modal
+- **WHEN** the host clicks "Approve" on a pending request in the approval modal
+- **THEN** the system SHALL add the song to the queue via `addRequestToQueueWithSinger`, preserving singer auto-assignment
+
+#### Scenario: Manual-approval reminder badge is visible while hosting
+- **WHEN** a hosted session is active and `auto_accept_guest_requests` is `false`
+- **THEN** `HostSessionModal` SHALL display a `Manual approval: ON` badge near the join code
+- **AND** when the setting is `true` (default), the badge SHALL NOT be rendered
+
+#### Scenario: Re-enabling auto-accept resumes auto-routing on the next poll
+- **WHEN** the host toggles `auto_accept_guest_requests` from `false` to `true` while a session is active
+- **THEN** subsequent pending requests SHALL be auto-routed to the queue per the default behaviour
+- **AND** any pending requests still in the approval modal at toggle time SHALL remain pending until the next poll picks them up
+

--- a/src/components/session/HostSessionModal.test.tsx
+++ b/src/components/session/HostSessionModal.test.tsx
@@ -55,7 +55,7 @@ vi.mock("lucide-react", () => ({
   StopCircle: () => <span />,
   Users: () => <span />,
   Clock: () => <span />,
-  Zap: () => <span data-testid="zap-icon" />,
+  ShieldCheck: () => <span data-testid="shield-icon" />,
 }));
 
 function setup(autoAccept: boolean) {
@@ -78,22 +78,22 @@ function setup(autoAccept: boolean) {
   };
 }
 
-describe("HostSessionModal — auto-accept badge", () => {
+describe("HostSessionModal — manual-approval badge", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("shows the Auto-accept: ON badge when setting is true", () => {
-    setup(true);
-    render(<HostSessionModal />);
-    const badge = screen.getByTestId("auto-accept-badge");
-    expect(badge).toBeInTheDocument();
-    expect(badge).toHaveTextContent("Auto-accept: ON");
-  });
-
-  it("does not render the badge when setting is false", () => {
+  it("shows the Manual approval: ON badge when auto-accept is off (host opted out)", () => {
     setup(false);
     render(<HostSessionModal />);
-    expect(screen.queryByTestId("auto-accept-badge")).not.toBeInTheDocument();
+    const badge = screen.getByTestId("manual-approval-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("Manual approval: ON");
+  });
+
+  it("does not render the badge when auto-accept is on (default)", () => {
+    setup(true);
+    render(<HostSessionModal />);
+    expect(screen.queryByTestId("manual-approval-badge")).not.toBeInTheDocument();
   });
 });

--- a/src/components/session/HostSessionModal.test.tsx
+++ b/src/components/session/HostSessionModal.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HostSessionModal } from "./HostSessionModal";
+
+interface MockHostedSession {
+  id: string;
+  sessionCode: string;
+  joinUrl: string;
+  qrCodeUrl: string;
+  stats: { totalGuests: number; pendingRequests: number };
+}
+
+interface MockSessionState {
+  hostedSession: MockHostedSession | null;
+  showHostModal: boolean;
+  closeHostModal: ReturnType<typeof vi.fn>;
+  stopHosting: ReturnType<typeof vi.fn>;
+}
+
+interface MockSettingsState {
+  settings: Record<string, string>;
+}
+
+let mockSessionStore: MockSessionState;
+let mockSettingsStore: MockSettingsState;
+
+vi.mock("../../stores", () => ({
+  useSessionStore: () => mockSessionStore,
+}));
+
+vi.mock("../../stores/settingsStore", () => ({
+  SETTINGS_KEYS: {
+    AUTO_ACCEPT_GUEST_REQUESTS: "auto_accept_guest_requests",
+  },
+  useSettingsStore: (selector?: (state: MockSettingsState) => unknown) => {
+    if (selector) {
+      return selector(mockSettingsStore);
+    }
+    return mockSettingsStore;
+  },
+}));
+
+vi.mock("../../stores/notificationStore", () => ({
+  notify: vi.fn(),
+}));
+
+vi.mock("./JoinCodeQR", () => ({
+  JoinCodeQR: () => <div data-testid="qr-mock" />,
+}));
+
+vi.mock("lucide-react", () => ({
+  X: () => <span />,
+  Copy: () => <span />,
+  Check: () => <span />,
+  StopCircle: () => <span />,
+  Users: () => <span />,
+  Clock: () => <span />,
+  Zap: () => <span data-testid="zap-icon" />,
+}));
+
+function setup(autoAccept: boolean) {
+  mockSessionStore = {
+    hostedSession: {
+      id: "session-1",
+      sessionCode: "HK-TEST-0001",
+      joinUrl: "https://homekaraoke.app/join/HK-TEST-0001",
+      qrCodeUrl: "https://example.com/qr",
+      stats: { totalGuests: 1, pendingRequests: 0 },
+    },
+    showHostModal: true,
+    closeHostModal: vi.fn(),
+    stopHosting: vi.fn(),
+  };
+  mockSettingsStore = {
+    settings: {
+      auto_accept_guest_requests: autoAccept ? "true" : "false",
+    },
+  };
+}
+
+describe("HostSessionModal — auto-accept badge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the Auto-accept: ON badge when setting is true", () => {
+    setup(true);
+    render(<HostSessionModal />);
+    const badge = screen.getByTestId("auto-accept-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("Auto-accept: ON");
+  });
+
+  it("does not render the badge when setting is false", () => {
+    setup(false);
+    render(<HostSessionModal />);
+    expect(screen.queryByTestId("auto-accept-badge")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/session/HostSessionModal.tsx
+++ b/src/components/session/HostSessionModal.tsx
@@ -78,7 +78,7 @@ export function HostSessionModal() {
           </p>
           {manualApproval && (
             <div
-              className="inline-flex items-center gap-1 mt-3 px-2 py-0.5 bg-amber-900/50 border border-amber-700 rounded text-xs text-amber-200"
+              className="inline-flex items-center gap-1 mt-3 px-2 py-0.5 bg-yellow-900/40 border border-yellow-700 rounded text-xs text-yellow-200"
               data-testid="manual-approval-badge"
             >
               <ShieldCheck size={12} />

--- a/src/components/session/HostSessionModal.tsx
+++ b/src/components/session/HostSessionModal.tsx
@@ -1,11 +1,15 @@
 import { useState } from "react";
-import { X, Copy, Check, StopCircle, Users, Clock } from "lucide-react";
+import { X, Copy, Check, StopCircle, Users, Clock, Zap } from "lucide-react";
 import { useSessionStore } from "../../stores";
+import { useSettingsStore, SETTINGS_KEYS } from "../../stores/settingsStore";
 import { notify } from "../../stores/notificationStore";
 import { JoinCodeQR } from "./JoinCodeQR";
 
 export function HostSessionModal() {
   const { hostedSession, showHostModal, closeHostModal, stopHosting } = useSessionStore();
+  const autoAccept = useSettingsStore(
+    (state) => state.settings[SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS] === "true",
+  );
   const [copiedCode, setCopiedCode] = useState(false);
   const [copiedLink, setCopiedLink] = useState(false);
   const [isStoppingHost, setIsStoppingHost] = useState(false);
@@ -71,6 +75,15 @@ export function HostSessionModal() {
           <p className="text-4xl font-bold font-mono text-white tracking-wider">
             {hostedSession.sessionCode}
           </p>
+          {autoAccept && (
+            <div
+              className="inline-flex items-center gap-1 mt-3 px-2 py-0.5 bg-blue-900/50 border border-blue-700 rounded text-xs text-blue-200"
+              data-testid="auto-accept-badge"
+            >
+              <Zap size={12} />
+              <span>Auto-accept: ON</span>
+            </div>
+          )}
         </div>
 
         {/* QR Code */}

--- a/src/components/session/HostSessionModal.tsx
+++ b/src/components/session/HostSessionModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { X, Copy, Check, StopCircle, Users, Clock, Zap } from "lucide-react";
+import { X, Copy, Check, StopCircle, Users, Clock, ShieldCheck } from "lucide-react";
 import { useSessionStore } from "../../stores";
 import { useSettingsStore, SETTINGS_KEYS } from "../../stores/settingsStore";
 import { notify } from "../../stores/notificationStore";
@@ -7,8 +7,9 @@ import { JoinCodeQR } from "./JoinCodeQR";
 
 export function HostSessionModal() {
   const { hostedSession, showHostModal, closeHostModal, stopHosting } = useSessionStore();
-  const autoAccept = useSettingsStore(
-    (state) => state.settings[SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS] === "true",
+  // Auto-accept is on by default; only badge when the host has opted into manual approval.
+  const manualApproval = useSettingsStore(
+    (state) => state.settings[SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS] === "false",
   );
   const [copiedCode, setCopiedCode] = useState(false);
   const [copiedLink, setCopiedLink] = useState(false);
@@ -75,13 +76,13 @@ export function HostSessionModal() {
           <p className="text-4xl font-bold font-mono text-white tracking-wider">
             {hostedSession.sessionCode}
           </p>
-          {autoAccept && (
+          {manualApproval && (
             <div
-              className="inline-flex items-center gap-1 mt-3 px-2 py-0.5 bg-blue-900/50 border border-blue-700 rounded text-xs text-blue-200"
-              data-testid="auto-accept-badge"
+              className="inline-flex items-center gap-1 mt-3 px-2 py-0.5 bg-amber-900/50 border border-amber-700 rounded text-xs text-amber-200"
+              data-testid="manual-approval-badge"
             >
-              <Zap size={12} />
-              <span>Auto-accept: ON</span>
+              <ShieldCheck size={12} />
+              <span>Manual approval: ON</span>
             </div>
           )}
         </div>

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -480,7 +480,7 @@ function QueueSettings({ getSetting, setSetting }: SettingsSectionProps) {
 
         <SettingRow
           label="Auto-accept guest requests"
-          description="Skip approval — incoming requests go straight to the queue"
+          description="On by default. Turn off to review each request before it joins the queue."
         >
           <ToggleSwitch
             checked={getSetting(SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS) === "true"}

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -474,6 +474,23 @@ function QueueSettings({ getSetting, setSetting }: SettingsSectionProps) {
     <div>
       <h4 className="text-lg font-medium text-white mb-4">Queue & History</h4>
 
+      {/* Hosted Session Section */}
+      <div className="mb-6">
+        <div className="text-sm font-medium text-gray-300 mb-3">Hosted Session</div>
+
+        <SettingRow
+          label="Auto-accept guest requests"
+          description="Skip approval — incoming requests go straight to the queue"
+        >
+          <ToggleSwitch
+            checked={getSetting(SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS) === "true"}
+            onChange={(v) =>
+              handleChange(SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS, v ? "true" : "false")
+            }
+          />
+        </SettingRow>
+      </div>
+
       {/* Search History Section */}
       <div className="mb-6">
         <div className="text-sm font-medium text-gray-300 mb-3">Search History</div>

--- a/src/stores/sessionStore.test.ts
+++ b/src/stores/sessionStore.test.ts
@@ -108,6 +108,18 @@ vi.mock("./notificationStore", () => ({
   notify: vi.fn(),
 }));
 
+// Mock settingsStore (getSetting; default values returned)
+vi.mock("./settingsStore", () => ({
+  SETTINGS_KEYS: {
+    AUTO_ACCEPT_GUEST_REQUESTS: "auto_accept_guest_requests",
+  },
+  useSettingsStore: {
+    getState: vi.fn(() => ({
+      getSetting: vi.fn(() => "false"),
+    })),
+  },
+}));
+
 // Mock authStore
 vi.mock("./authStore", () => ({
   useAuthStore: {
@@ -171,6 +183,14 @@ import { authService } from "../services/auth";
 import { useQueueStore, flushPendingOperations } from "./queueStore";
 import { notify } from "./notificationStore";
 import { useAuthStore } from "./authStore";
+import { useSettingsStore } from "./settingsStore";
+
+function setAutoAccept(enabled: boolean) {
+  vi.mocked(useSettingsStore.getState).mockReturnValue({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getSetting: vi.fn(() => (enabled ? "true" : "false")),
+  } as any);
+}
 
 const mockSession: Session = {
   id: 1,
@@ -3272,6 +3292,315 @@ describe("sessionStore - Host Session", () => {
 
       // Verify modal opens
       expect(useSessionStore.getState().showRequestsModal).toBe(true);
+    });
+
+    describe("auto-accept guest requests (#231)", () => {
+      const mockSongRequest = {
+        id: "req-1",
+        hosted_session_id: "session-123",
+        user_id: "user-A",
+        guest_name: "Alice",
+        youtube_id: "yt-abc",
+        title: "Don't Stop Believin'",
+        artist: "Journey",
+        duration: 251,
+        thumbnail_url: null,
+        status: "pending" as const,
+        requested_at: "2026-05-16T10:00:00Z",
+      };
+
+      beforeEach(() => {
+        setAutoAccept(false);
+        vi.mocked(notify).mockClear();
+        vi.mocked(hostedSessionService.getRequests).mockReset();
+        vi.mocked(hostedSessionService.approveRequest).mockReset();
+        vi.mocked(useQueueStore.getState).mockReturnValue(createMockQueueState());
+      });
+
+      it("shows manual notification when auto-accept is off (default)", async () => {
+        setAutoAccept(false);
+        useSessionStore.setState({
+          hostedSession: mockRefreshHostedSession,
+          previousPendingCount: 0,
+          _isRefreshingHostedSession: false,
+        } as Parameters<typeof useSessionStore.setState>[0]);
+        vi.mocked(authService.getTokens).mockResolvedValue(mockTokens);
+        vi.mocked(hostedSessionService.getSession).mockResolvedValue({
+          ...mockRefreshHostedSession,
+          stats: { pendingRequests: 2, approvedRequests: 0, totalGuests: 1 },
+        });
+
+        await useSessionStore.getState().refreshHostedSession();
+
+        expect(notify).toHaveBeenCalledWith(
+          "info",
+          "2 new song requests",
+          expect.objectContaining({ label: "View" }),
+        );
+        expect(hostedSessionService.getRequests).not.toHaveBeenCalled();
+      });
+
+      it("invokes autoAcceptNewRequests instead of notifying when setting is on", async () => {
+        setAutoAccept(true);
+        useSessionStore.setState({
+          hostedSession: mockRefreshHostedSession,
+          previousPendingCount: 0,
+          _isRefreshingHostedSession: false,
+        } as Parameters<typeof useSessionStore.setState>[0]);
+        vi.mocked(authService.getTokens).mockResolvedValue(mockTokens);
+        vi.mocked(hostedSessionService.getSession).mockResolvedValue({
+          ...mockRefreshHostedSession,
+          stats: { pendingRequests: 1, approvedRequests: 0, totalGuests: 1 },
+        });
+        vi.mocked(hostedSessionService.getRequests).mockResolvedValue([]);
+
+        const spy = vi
+          .spyOn(useSessionStore.getState(), "autoAcceptNewRequests")
+          .mockResolvedValue(undefined);
+
+        try {
+          await useSessionStore.getState().refreshHostedSession();
+
+          expect(spy).toHaveBeenCalled();
+          expect(notify).not.toHaveBeenCalledWith(
+            "info",
+            expect.stringContaining("new song request"),
+            expect.anything(),
+          );
+        } finally {
+          spy.mockRestore();
+        }
+      });
+
+      it("autoAcceptNewRequests adds each pending request to queue and emits passive toast", async () => {
+        setAutoAccept(true);
+        useSessionStore.setState({
+          hostedSession: mockRefreshHostedSession,
+          singers: [],
+          pendingRequests: [],
+        } as Parameters<typeof useSessionStore.setState>[0]);
+        vi.mocked(authService.getTokens).mockResolvedValue(mockTokens);
+        vi.mocked(hostedSessionService.getRequests).mockResolvedValue([mockSongRequest]);
+        vi.mocked(useQueueStore.getState).mockReturnValue(
+          createMockQueueState({ queue: [], history: [] }),
+        );
+        vi.mocked(useQueueStore.getState().addToQueue).mockResolvedValue({
+          id: "q-1",
+          videoId: "yt-abc",
+          title: "Don't Stop Believin'",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        vi.mocked(sessionService.createSinger).mockResolvedValue(mockSinger1);
+        vi.mocked(sessionService.addSingerToSession).mockResolvedValue(undefined);
+        vi.mocked(sessionService.assignSingerToQueueItem).mockResolvedValue(undefined);
+        vi.mocked(hostedSessionService.approveRequest).mockResolvedValue(undefined);
+
+        await useSessionStore.getState().autoAcceptNewRequests();
+
+        expect(useQueueStore.getState().addToQueue).toHaveBeenCalled();
+        expect(notify).toHaveBeenCalledWith(
+          "info",
+          "Alice added Don't Stop Believin' to the queue",
+        );
+        // Pending list cleared optimistically
+        expect(useSessionStore.getState().pendingRequests).toEqual([]);
+      });
+
+      it("autoAcceptNewRequests is a no-op when there are no pending requests", async () => {
+        setAutoAccept(true);
+        useSessionStore.setState({
+          hostedSession: mockRefreshHostedSession,
+        } as Parameters<typeof useSessionStore.setState>[0]);
+        vi.mocked(authService.getTokens).mockResolvedValue(mockTokens);
+        vi.mocked(hostedSessionService.getRequests).mockResolvedValue([]);
+
+        await useSessionStore.getState().autoAcceptNewRequests();
+
+        expect(notify).not.toHaveBeenCalled();
+        expect(useQueueStore.getState().addToQueue).not.toHaveBeenCalled();
+      });
+
+      it("skips a request that has no youtube_id (does not toast, does not call approveRequest)", async () => {
+        setAutoAccept(true);
+        const missingYt = { ...mockSongRequest, id: "req-noyt", youtube_id: null };
+        const valid = { ...mockSongRequest, id: "req-ok" };
+        useSessionStore.setState({
+          hostedSession: mockRefreshHostedSession,
+          singers: [],
+          pendingRequests: [],
+        } as Parameters<typeof useSessionStore.setState>[0]);
+        vi.mocked(authService.getTokens).mockResolvedValue(mockTokens);
+        vi.mocked(hostedSessionService.getRequests).mockResolvedValue([missingYt, valid]);
+        vi.mocked(useQueueStore.getState).mockReturnValue(createMockQueueState());
+        vi.mocked(useQueueStore.getState().addToQueue).mockResolvedValue(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { id: "q-1", videoId: "yt-abc", title: "ok" } as any,
+        );
+        vi.mocked(sessionService.createSinger).mockResolvedValue(mockSinger1);
+        vi.mocked(sessionService.assignSingerToQueueItem).mockResolvedValue(undefined);
+        vi.mocked(hostedSessionService.approveRequest).mockResolvedValue(undefined);
+
+        await useSessionStore.getState().autoAcceptNewRequests();
+
+        // addToQueue invoked only for the valid request
+        expect(useQueueStore.getState().addToQueue).toHaveBeenCalledTimes(1);
+        // Exactly one toast (for the valid request)
+        const infoToasts = vi.mocked(notify).mock.calls.filter(
+          (c) => c[0] === "info" && typeof c[1] === "string" && c[1].includes("added"),
+        );
+        expect(infoToasts).toHaveLength(1);
+      });
+
+      it("continues processing remaining requests after one fails mid-iteration", async () => {
+        setAutoAccept(true);
+        const first = { ...mockSongRequest, id: "req-a", title: "First" };
+        const second = { ...mockSongRequest, id: "req-b", title: "Second" };
+        useSessionStore.setState({
+          hostedSession: mockRefreshHostedSession,
+          singers: [],
+          pendingRequests: [],
+        } as Parameters<typeof useSessionStore.setState>[0]);
+        vi.mocked(authService.getTokens).mockResolvedValue(mockTokens);
+        vi.mocked(hostedSessionService.getRequests).mockResolvedValue([first, second]);
+        vi.mocked(useQueueStore.getState).mockReturnValue(createMockQueueState());
+        vi.mocked(useQueueStore.getState().addToQueue)
+          .mockRejectedValueOnce(new Error("transient queue write"))
+          .mockResolvedValueOnce(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            { id: "q-2", videoId: "yt-abc", title: "Second" } as any,
+          );
+        vi.mocked(sessionService.createSinger).mockResolvedValue(mockSinger1);
+        vi.mocked(sessionService.assignSingerToQueueItem).mockResolvedValue(undefined);
+        vi.mocked(hostedSessionService.approveRequest).mockResolvedValue(undefined);
+
+        await useSessionStore.getState().autoAcceptNewRequests();
+
+        // Both requests attempted; second succeeded
+        expect(useQueueStore.getState().addToQueue).toHaveBeenCalledTimes(2);
+        const infoToasts = vi.mocked(notify).mock.calls.filter(
+          (c) => c[0] === "info" && typeof c[1] === "string" && c[1].includes("Second"),
+        );
+        expect(infoToasts).toHaveLength(1);
+      });
+
+      it("emits one passive toast per request when multiple arrive in one batch", async () => {
+        setAutoAccept(true);
+        const reqs = [
+          { ...mockSongRequest, id: "r1", title: "S1" },
+          { ...mockSongRequest, id: "r2", title: "S2" },
+          { ...mockSongRequest, id: "r3", title: "S3" },
+        ];
+        useSessionStore.setState({
+          hostedSession: mockRefreshHostedSession,
+          singers: [],
+          pendingRequests: [],
+        } as Parameters<typeof useSessionStore.setState>[0]);
+        vi.mocked(authService.getTokens).mockResolvedValue(mockTokens);
+        vi.mocked(hostedSessionService.getRequests).mockResolvedValue(reqs);
+        vi.mocked(useQueueStore.getState).mockReturnValue(createMockQueueState());
+        vi.mocked(useQueueStore.getState().addToQueue).mockResolvedValue(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { id: "q", videoId: "yt-abc", title: "x" } as any,
+        );
+        vi.mocked(sessionService.createSinger).mockResolvedValue(mockSinger1);
+        vi.mocked(sessionService.assignSingerToQueueItem).mockResolvedValue(undefined);
+        vi.mocked(hostedSessionService.approveRequest).mockResolvedValue(undefined);
+
+        await useSessionStore.getState().autoAcceptNewRequests();
+
+        const songToasts = vi.mocked(notify).mock.calls.filter(
+          (c) => c[0] === "info" && typeof c[1] === "string" && /added S\d to the queue/.test(c[1]),
+        );
+        expect(songToasts).toHaveLength(3);
+        // No View-action toast in the auto-accept path
+        for (const call of songToasts) {
+          expect(call[2]).toBeUndefined();
+        }
+      });
+
+      it("does not revert optimistic state when server approveRequest fails", async () => {
+        setAutoAccept(true);
+        useSessionStore.setState({
+          hostedSession: mockRefreshHostedSession,
+          singers: [],
+          pendingRequests: [],
+        } as Parameters<typeof useSessionStore.setState>[0]);
+        vi.mocked(authService.getTokens).mockResolvedValue(mockTokens);
+        vi.mocked(hostedSessionService.getRequests).mockResolvedValue([mockSongRequest]);
+        vi.mocked(useQueueStore.getState).mockReturnValue(createMockQueueState());
+        vi.mocked(useQueueStore.getState().addToQueue).mockResolvedValue(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { id: "q", videoId: "yt-abc", title: "x" } as any,
+        );
+        vi.mocked(sessionService.createSinger).mockResolvedValue(mockSinger1);
+        vi.mocked(sessionService.assignSingerToQueueItem).mockResolvedValue(undefined);
+        // Server rejection: should not surface as error toast, optimistic state preserved
+        vi.mocked(hostedSessionService.approveRequest).mockRejectedValue(new Error("500"));
+        // refreshHostedSession reconciliation: keep stable
+        vi.mocked(hostedSessionService.getSession).mockResolvedValue({
+          ...mockRefreshHostedSession,
+          stats: { pendingRequests: 0, approvedRequests: 1, totalGuests: 1 },
+        });
+
+        await useSessionStore.getState().autoAcceptNewRequests();
+        // Let pending microtasks (server sync + reconcile) flush
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Pending list still empty, no error toast fired
+        expect(useSessionStore.getState().pendingRequests).toEqual([]);
+        const errorToasts = vi.mocked(notify).mock.calls.filter((c) => c[0] === "error");
+        expect(errorToasts).toHaveLength(0);
+      });
+
+      it("toggling setting between polls changes routing on next poll", async () => {
+        // First poll: auto-accept OFF
+        setAutoAccept(false);
+        useSessionStore.setState({
+          hostedSession: mockRefreshHostedSession,
+          previousPendingCount: 0,
+          _isRefreshingHostedSession: false,
+        } as Parameters<typeof useSessionStore.setState>[0]);
+        vi.mocked(authService.getTokens).mockResolvedValue(mockTokens);
+        vi.mocked(hostedSessionService.getSession).mockResolvedValue({
+          ...mockRefreshHostedSession,
+          stats: { pendingRequests: 1, approvedRequests: 0, totalGuests: 1 },
+        });
+
+        await useSessionStore.getState().refreshHostedSession();
+        expect(notify).toHaveBeenCalledWith(
+          "info",
+          "1 new song request",
+          expect.objectContaining({ label: "View" }),
+        );
+
+        // Flip setting and run another poll where count grows again
+        setAutoAccept(true);
+        vi.mocked(notify).mockClear();
+        useSessionStore.setState({
+          previousPendingCount: 1,
+          _isRefreshingHostedSession: false,
+        } as Parameters<typeof useSessionStore.setState>[0]);
+        vi.mocked(hostedSessionService.getSession).mockResolvedValue({
+          ...mockRefreshHostedSession,
+          stats: { pendingRequests: 3, approvedRequests: 0, totalGuests: 1 },
+        });
+        const spy = vi
+          .spyOn(useSessionStore.getState(), "autoAcceptNewRequests")
+          .mockResolvedValue(undefined);
+
+        try {
+          await useSessionStore.getState().refreshHostedSession();
+
+          expect(spy).toHaveBeenCalled();
+          expect(notify).not.toHaveBeenCalledWith(
+            "info",
+            expect.stringContaining("new song request"),
+            expect.anything(),
+          );
+        } finally {
+          spy.mockRestore();
+        }
+      });
     });
   });
 

--- a/src/stores/sessionStore.test.ts
+++ b/src/stores/sessionStore.test.ts
@@ -108,14 +108,14 @@ vi.mock("./notificationStore", () => ({
   notify: vi.fn(),
 }));
 
-// Mock settingsStore (getSetting; default values returned)
+// Mock settingsStore (getSetting; default mirrors production "true")
 vi.mock("./settingsStore", () => ({
   SETTINGS_KEYS: {
     AUTO_ACCEPT_GUEST_REQUESTS: "auto_accept_guest_requests",
   },
   useSettingsStore: {
     getState: vi.fn(() => ({
-      getSetting: vi.fn(() => "false"),
+      getSetting: vi.fn(() => "true"),
     })),
   },
 }));
@@ -2863,6 +2863,9 @@ describe("sessionStore - Host Session", () => {
         hostedSession: null,
         showHostModal: false,
       } as Parameters<typeof useSessionStore.setState>[0]);
+      // Existing tests in this describe assert the manual approval flow.
+      // Auto-accept is on by default in production, so lock it off here.
+      setAutoAccept(false);
     });
 
     it("should do nothing if no hosted session exists", async () => {

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -20,6 +20,7 @@ import { getNextSingerColor } from "../constants";
 import { useQueueStore, flushPendingOperations } from "./queueStore";
 import { notify } from "./notificationStore";
 import { useAuthStore } from "./authStore";
+import { useSettingsStore, SETTINGS_KEYS } from "./settingsStore";
 import type { Video } from "./playerStore";
 
 const log = createLogger("SessionStore");
@@ -183,6 +184,7 @@ interface SessionState {
   approveRequest: (requestId: string) => Promise<void>;
   rejectRequest: (requestId: string) => Promise<void>;
   approveAllRequests: (guestName?: string) => Promise<void>;
+  autoAcceptNewRequests: () => Promise<void>;
   openRequestsModal: () => void;
   closeRequestsModal: () => void;
 
@@ -972,7 +974,11 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       const previousCount = get().previousPendingCount;
       const newCount = updated.stats.pendingRequests;
 
-      if (newCount > previousCount && previousCount >= 0) {
+      const autoAccept =
+        newCount > previousCount && previousCount >= 0 &&
+        useSettingsStore.getState().getSetting(SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS) === "true";
+
+      if (newCount > previousCount && previousCount >= 0 && !autoAccept) {
         const diff = newCount - previousCount;
         notify("info", `${diff} new song request${diff > 1 ? "s" : ""}`, {
           label: "View",
@@ -980,13 +986,18 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         });
       }
 
-      // Only update stats, preserve other fields from the original session
+      // Update stats; previousPendingCount is owned by autoAcceptNewRequests when it runs,
+      // so that a fetch failure there leaves the gate open for the next poll to retry.
       set((state) => ({
         hostedSession: state.hostedSession
           ? { ...state.hostedSession, stats: updated.stats, status: updated.status }
           : null,
-        previousPendingCount: newCount,
+        ...(autoAccept ? {} : { previousPendingCount: newCount }),
       }));
+
+      if (autoAccept) {
+        void get().autoAcceptNewRequests();
+      }
 
       // Emit signal after successful stats update
       await emitSignal(APP_SIGNALS.HOSTED_SESSION_UPDATED, updated.stats);
@@ -1463,6 +1474,118 @@ export const useSessionStore = create<SessionState>((set, get) => ({
         updatedProcessing.delete(id);
       }
       set({ processingRequestIds: updatedProcessing });
+    }
+  },
+
+  autoAcceptNewRequests: async () => {
+    const { hostedSession } = get();
+    if (!hostedSession) {
+      log.debug("Cannot auto-accept: no hosted session");
+      return;
+    }
+
+    const tokens = await authService.getTokens();
+    if (!tokens) {
+      log.error("Cannot auto-accept: not authenticated");
+      return;
+    }
+
+    // Fetch directly (not via loadPendingRequests) so a failure stays quiet
+    // and does not show the manual-flow error toast.
+    let requests: SongRequest[];
+    try {
+      requests = await hostedSessionService.getRequests(
+        tokens.access_token,
+        hostedSession.id,
+        "pending",
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error(`Auto-accept fetch failed: ${message}`);
+      return;
+    }
+
+    // Skip ids already being handled by approveRequest/approveAllRequests to avoid double-processing.
+    const inFlight = get().processingRequestIds;
+    const eligible = requests.filter((r) => !inFlight.has(r.id));
+    if (eligible.length === 0) {
+      // Bump the count gate so the next poll re-evaluates the diff cleanly.
+      set({ previousPendingCount: get().hostedSession?.stats.pendingRequests ?? 0 });
+      return;
+    }
+
+    const eligibleIds = eligible.map((r) => r.id);
+    const newProcessing = new Set(inFlight);
+    for (const id of eligibleIds) newProcessing.add(id);
+    set({ processingRequestIds: newProcessing });
+
+    log.debug(`Auto-accepting ${eligible.length} pending request(s)`);
+    const acceptedIds: string[] = [];
+
+    try {
+      for (const request of eligible) {
+        try {
+          const added = await addRequestToQueueWithSinger(request, get);
+          if (!added) {
+            log.warn(`Auto-accept skipped request ${request.id}: no youtube_id`);
+            continue;
+          }
+          acceptedIds.push(request.id);
+          notify("info", `${request.guest_name} added ${request.title} to the queue`);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          log.error(`Auto-accept failed for request ${request.id}: ${message}`);
+        }
+      }
+
+      if (acceptedIds.length === 0) {
+        set({ previousPendingCount: get().hostedSession?.stats.pendingRequests ?? 0 });
+        return;
+      }
+
+      // Optimistically remove accepted requests and decrement count.
+      set((state) => ({
+        pendingRequests: state.pendingRequests.filter((r) => !acceptedIds.includes(r.id)),
+        hostedSession: state.hostedSession
+          ? {
+              ...state.hostedSession,
+              stats: {
+                ...state.hostedSession.stats,
+                pendingRequests: Math.max(
+                  0,
+                  state.hostedSession.stats.pendingRequests - acceptedIds.length,
+                ),
+              },
+            }
+          : null,
+        previousPendingCount: Math.max(
+          0,
+          (state.hostedSession?.stats.pendingRequests ?? 0) - acceptedIds.length,
+        ),
+      }));
+
+      // Notify server in background, then refresh to reconcile. Mirrors approveAllRequests.
+      void Promise.allSettled(
+        acceptedIds.map((requestId) =>
+          hostedSessionService.approveRequest(tokens.access_token, hostedSession.id, requestId),
+        ),
+      )
+        .then(async (results) => {
+          const failed = results.filter((r) => r.status === "rejected").length;
+          if (failed > 0) {
+            log.error(`Auto-accept server sync: ${failed}/${acceptedIds.length} failed`);
+          }
+          await get().refreshHostedSession();
+        })
+        .catch((error) => {
+          const message = error instanceof Error ? error.message : String(error);
+          log.error(`Auto-accept post-sync failed: ${message}`);
+        });
+    } finally {
+      const current = get().processingRequestIds;
+      const next = new Set(current);
+      for (const id of eligibleIds) next.delete(id);
+      set({ processingRequestIds: next });
     }
   },
 

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -996,7 +996,12 @@ export const useSessionStore = create<SessionState>((set, get) => ({
       }));
 
       if (autoAccept) {
-        void get().autoAcceptNewRequests();
+        void get()
+          .autoAcceptNewRequests()
+          .catch((err) => {
+            const message = err instanceof Error ? err.message : String(err);
+            log.error(`Auto-accept dispatch failed: ${message}`);
+          });
       }
 
       // Emit signal after successful stats update

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -6,11 +6,19 @@ describe("settingsStore", () => {
     it("should have FAIR_QUEUE_ENABLED key", () => {
       expect(SETTINGS_KEYS.FAIR_QUEUE_ENABLED).toBe("fair_queue_enabled");
     });
+
+    it("should have AUTO_ACCEPT_GUEST_REQUESTS key", () => {
+      expect(SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS).toBe("auto_accept_guest_requests");
+    });
   });
 
   describe("SETTINGS_DEFAULTS", () => {
     it("should have FAIR_QUEUE_ENABLED default set to 'false'", () => {
       expect(SETTINGS_DEFAULTS[SETTINGS_KEYS.FAIR_QUEUE_ENABLED]).toBe("false");
+    });
+
+    it("should have AUTO_ACCEPT_GUEST_REQUESTS default set to 'false'", () => {
+      expect(SETTINGS_DEFAULTS[SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS]).toBe("false");
     });
   });
 });

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -17,8 +17,8 @@ describe("settingsStore", () => {
       expect(SETTINGS_DEFAULTS[SETTINGS_KEYS.FAIR_QUEUE_ENABLED]).toBe("false");
     });
 
-    it("should have AUTO_ACCEPT_GUEST_REQUESTS default set to 'false'", () => {
-      expect(SETTINGS_DEFAULTS[SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS]).toBe("false");
+    it("should have AUTO_ACCEPT_GUEST_REQUESTS default set to 'true' (opt-out)", () => {
+      expect(SETTINGS_DEFAULTS[SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS]).toBe("true");
     });
   });
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -59,7 +59,7 @@ export const SETTINGS_DEFAULTS: Record<string, string> = {
   [SETTINGS_KEYS.PLAYBACK_MODE]: "youtube", // Default to YouTube embed
   [SETTINGS_KEYS.LAST_VOLUME]: "1", // Default to 100% volume
   [SETTINGS_KEYS.FAIR_QUEUE_ENABLED]: "false", // Default to disabled (append to end)
-  [SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS]: "false", // Default to manual approval
+  [SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS]: "true", // Default on; hosts opt OUT for manual approval
 };
 
 export type SettingsTab = "playback" | "display" | "queue" | "library" | "youtube" | "advanced" | "about";

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -33,6 +33,8 @@ export const SETTINGS_KEYS = {
   PLAYBACK_MODE: "playback_mode", // 'youtube' | 'ytdlp'
   // Queue behavior
   FAIR_QUEUE_ENABLED: "fair_queue_enabled", // 'true' | 'false'
+  // Hosted session
+  AUTO_ACCEPT_GUEST_REQUESTS: "auto_accept_guest_requests", // 'true' | 'false'
   // Internal (not shown in UI, used for caching)
   YTDLP_AVAILABLE: "ytdlp_available", // 'true' | 'false' | '' (not checked)
   LAST_VOLUME: "last_volume", // remembered volume level (0-1 as string)
@@ -57,6 +59,7 @@ export const SETTINGS_DEFAULTS: Record<string, string> = {
   [SETTINGS_KEYS.PLAYBACK_MODE]: "youtube", // Default to YouTube embed
   [SETTINGS_KEYS.LAST_VOLUME]: "1", // Default to 100% volume
   [SETTINGS_KEYS.FAIR_QUEUE_ENABLED]: "false", // Default to disabled (append to end)
+  [SETTINGS_KEYS.AUTO_ACCEPT_GUEST_REQUESTS]: "false", // Default to manual approval
 };
 
 export type SettingsTab = "playback" | "display" | "queue" | "library" | "youtube" | "advanced" | "about";


### PR DESCRIPTION
Closes #231.

## Summary
- Adds a new app-wide setting `auto_accept_guest_requests` (default **ON**, opt-out) in Settings → Queue & History.
- When on (default), incoming guest song requests bypass the approval modal and are added directly to the queue with singer auto-assignment from #215, firing a passive per-request toast.
- When the host opts out, the manual approval flow from #211 is preserved and `HostSessionModal` shows a `Manual approval: ON` badge near the join code as a visible reminder.
- Originally drafted as opt-in; flipped to opt-out after host-UX review (see #231 comment).

## Why opt-out
For typical home-karaoke hosting (small parties, family use) the approval modal is friction more than safety. Default-on matches the common case; hosts who genuinely need vetting can turn it off.

## Implementation notes
- `refreshHostedSession` branches on the setting; `previousPendingCount` ownership is deferred to the new `autoAcceptNewRequests` action so transient fetch failures retry on the next poll.
- `autoAcceptNewRequests` uses `processingRequestIds` (mirroring `approveAllRequests`) so manual approval and auto-accept never double-process the same request.
- Server-side approval failures are reconciled via a follow-up `refreshHostedSession` and logged with `log.error`; no error toast (auto-accept stays quiet).
- Spec captured under `openspec/specs/hosted-session-requests/spec.md` (first spec in this project).
- Also records the OpenSpec-driven workflow in `CLAUDE.md`.

## Test plan
- [x] `just check` (typecheck + lint + cargo) — clean
- [x] `just test` — 677/677 unit tests (incl. 9 new auto-accept tests covering: default branch, opt-out branch, missing `youtube_id`, mid-iteration failure, multi-request toasts, server failure non-fatal, toggle mid-session)
- [x] `just e2e` — 245 passed, 9 skipped (chromium + webkit)
- [ ] Manual smoke: host session with a guest, verify requests land on queue automatically and toast fires
- [ ] Manual smoke: toggle Settings → Queue → Auto-accept OFF, verify `Manual approval: ON` badge in HostSessionModal and approval modal flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)