### PR TITLE
feat: detached player always-on-top with hover toggle (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - When opted out, a `Manual approval: ON` badge appears in the Host Session modal as a visible reminder
 
 ### Added
+- Detached player window now stays on top of other windows (#178)
+  - Default ON, so the video stays visible while you browse or use other apps
+  - Hover-revealed pin button in the top-right toggles it on/off per session
 - OpenSpec-driven development workflow (#232)
   - Workflow recorded in `CLAUDE.md` (issue → explore → propose → branch → apply → review-and-fix → e2e → archive → PR)
   - First spec captured under `openspec/specs/hosted-session-requests/spec.md`

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "core:window:allow-outer-position",
     "core:window:allow-outer-size",
     "core:window:allow-start-dragging",
+    "core:window:allow-set-always-on-top",
     "core:event:default",
     "core:webview:allow-create-webview-window",
     "log:default",

--- a/src/components/player/DetachedPlayer.tsx
+++ b/src/components/player/DetachedPlayer.tsx
@@ -1,4 +1,6 @@
 import { useRef, useEffect, useCallback, useState } from "react";
+import { Pin, PinOff } from "lucide-react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { windowManager, type PlayerState } from "../../services/windowManager";
 import { createLogger } from "../../services";
 import { SETTINGS_KEYS, SETTINGS_DEFAULTS } from "../../stores";
@@ -11,7 +13,7 @@ import { SingerOverlayDisplay } from "./SingerOverlayDisplay";
 import { CURRENT_SINGER_OVERLAY_DURATION_MS } from "./CurrentSingerOverlay";
 import { YouTubePlayer } from "./YouTubePlayer";
 import { NativePlayer } from "./NativePlayer";
-import { Z_INDEX_DRAG_OVERLAY } from "../../styles/zIndex";
+import { Z_INDEX_AOT_BUTTON, Z_INDEX_DRAG_OVERLAY } from "../../styles/zIndex";
 import { JoinCodeQR } from "../session";
 
 const log = createLogger("DetachedPlayer");
@@ -21,6 +23,8 @@ const TIME_UPDATE_THROTTLE_MS = 500;
 
 // Minimum position (in seconds) to restore when reattaching - avoids seeking to near-zero
 export const MIN_RESTORE_POSITION_SECONDS = 1;
+
+const HOVER_CONTROLS_HIDE_DELAY_MS = 2000;
 
 export function DetachedPlayer() {
   const lastTimeUpdateRef = useRef<number>(0);
@@ -39,6 +43,10 @@ export function DetachedPlayer() {
   const previousVideoIdRef = useRef<string | null>(null);
   // Seek time from main window
   const [seekTime, setSeekTime] = useState<number | null>(null);
+  // Always-on-top toggle (window is created with alwaysOnTop=true in WindowManager)
+  const [alwaysOnTop, setAlwaysOnTop] = useState(true);
+  const [controlsVisible, setControlsVisible] = useState(false);
+  const hideControlsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [state, setState] = useState<PlayerState>({
     streamUrl: null,
     videoId: null,
@@ -285,6 +293,33 @@ export function DetachedPlayer() {
     // Volume is handled by the player components
   }, [state.volume, state.isMuted]);
 
+  useEffect(() => {
+    const showControls = () => {
+      setControlsVisible((visible) => (visible ? visible : true));
+      if (hideControlsTimerRef.current) clearTimeout(hideControlsTimerRef.current);
+      hideControlsTimerRef.current = setTimeout(
+        () => setControlsVisible(false),
+        HOVER_CONTROLS_HIDE_DELAY_MS,
+      );
+    };
+    window.addEventListener("mousemove", showControls);
+    return () => {
+      window.removeEventListener("mousemove", showControls);
+      if (hideControlsTimerRef.current) clearTimeout(hideControlsTimerRef.current);
+    };
+  }, []);
+
+  const toggleAlwaysOnTop = useCallback(async () => {
+    const next = !alwaysOnTop;
+    try {
+      await getCurrentWindow().setAlwaysOnTop(next);
+      setAlwaysOnTop(next);
+      log.info(`Always-on-top set to ${next}`);
+    } catch (err) {
+      log.error("Failed to toggle always-on-top:", err);
+    }
+  }, [alwaysOnTop]);
+
 
   // Determine what to play
   const playbackMode = state.playbackMode || "youtube";
@@ -386,6 +421,20 @@ export function DetachedPlayer() {
         style={{ zIndex: Z_INDEX_DRAG_OVERLAY }}
         onDoubleClick={toggleFullscreen}
       />
+      <button
+        type="button"
+        onClick={toggleAlwaysOnTop}
+        aria-label={alwaysOnTop ? "Disable always on top" : "Enable always on top"}
+        aria-pressed={alwaysOnTop}
+        title={alwaysOnTop ? "Always on top: on" : "Always on top: off"}
+        data-testid="aot-toggle"
+        className={`absolute top-3 right-3 rounded-full bg-black/60 hover:bg-black/80 text-white p-2 transition-opacity duration-200 ${
+          controlsVisible ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+        style={{ zIndex: Z_INDEX_AOT_BUTTON }}
+      >
+        {alwaysOnTop ? <Pin size={18} /> : <PinOff size={18} />}
+      </button>
     </div>
   );
 }

--- a/src/services/windowManager.ts
+++ b/src/services/windowManager.ts
@@ -186,6 +186,7 @@ class WindowManager {
         decorations: true,
         titleBarStyle: "overlay",
         center: true,
+        alwaysOnTop: true,
       });
 
       // Wait for the window to be created

--- a/src/styles/zIndex.ts
+++ b/src/styles/zIndex.ts
@@ -18,6 +18,9 @@ export const Z_INDEX_NEXT_SONG_OVERLAY = 30;
 /** Drag overlay for window dragging - below play overlay so clicks work */
 export const Z_INDEX_DRAG_OVERLAY = 40;
 
+/** Always-on-top toggle button in detached player - above drag overlay so it's clickable */
+export const Z_INDEX_AOT_BUTTON = 45;
+
 /** Click to play / autoplay blocked overlay - must be above singer overlay and drag overlay */
 export const Z_INDEX_PLAY_OVERLAY = 50;
 


### PR DESCRIPTION
Closes #178.

## Summary
- Detached player window now opens with `alwaysOnTop: true` so the karaoke video stays visible while the user browses for songs or uses other apps.
- A pin/unpin button (lucide `Pin` / `PinOff`) appears in the top-right of the detached player on any mouse movement and auto-hides after 2 s of idle time. Clicking it toggles `getCurrentWindow().setAlwaysOnTop(...)` for the current session.
- New Tauri capability `core:window:allow-set-always-on-top`.
- New z-index constant `Z_INDEX_AOT_BUTTON = 45`, sitting between the drag overlay (40) and the play overlay (50), so the button is clickable but doesn't shadow the click-to-play priming overlay.

## Notes
- Default is ON per the issue intent. State is per-session — not persisted across detaches. Persisting it via `SETTINGS_KEYS` would be a worthwhile follow-up (flagged in review) but exceeds the scope of this issue.
- Failure path: `getCurrentWindow().setAlwaysOnTop` is wrapped in a try/catch; failures log at `error` so a capability/permission misconfig surfaces in the feedback log tail (#225). UI state only flips on success.

## Test plan
- [ ] `just check` clean
- [ ] `just test` passes
- [ ] Manual: detach the player → window floats above other apps
- [ ] Manual: move mouse over the detached player → pin button appears top-right
- [ ] Manual: click pin → window drops behind other apps, icon flips to `PinOff`
- [ ] Manual: click again → window floats back on top, icon flips to `Pin`
- [ ] Manual: button auto-hides ~2 s after the mouse stops moving
- [ ] Manual: button doesn't block double-click-to-fullscreen on the rest of the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)