### PR TITLE
feat: add error boundary around DisplayRestoreDialog (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - When opted out, a `Manual approval: ON` badge appears in the Host Session modal as a visible reminder
 
 ### Added
+- Error boundary around `DisplayRestoreDialog` (#56)
+  - A render error in the layout-restore prompt now shows a dismiss-able fallback instead of crashing the app
+  - Dismissing also drops the pending restore so the broken dialog won't immediately re-mount
 - Detached player window now stays on top of other windows (#178)
   - Default ON, so the video stays visible while you browse or use other apps
   - Hover-revealed pin button in the top-right toggles it on/off per session

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import { LibraryBrowser, type LibraryBrowserRef } from "./components/library";
 import { DraggableQueueItem } from "./components/queue";
 import { SessionBar, HostedByOtherUserDialog, SongRequestsModal } from "./components/session";
 import { DependencyCheck } from "./components/DependencyCheck";
-import { DisplayRestoreDialog } from "./components/display";
+import { DisplayRestoreDialog, DisplayRestoreErrorBoundary } from "./components/display";
 import { LoadFavoritesDialog, ManageFavoritesDialog, FavoriteStar } from "./components/favorites";
 import { SettingsDialog } from "./components/settings";
 import { AuthStatus } from "./components/auth";
@@ -567,7 +567,9 @@ function App() {
       <NotificationBar />
 
       {/* Display configuration restore dialog */}
-      <DisplayRestoreDialog />
+      <DisplayRestoreErrorBoundary>
+        <DisplayRestoreDialog />
+      </DisplayRestoreErrorBoundary>
 
       {/* Hosted session ownership dialog */}
       <HostedByOtherUserDialog />

--- a/src/components/display/DisplayRestoreErrorBoundary.test.tsx
+++ b/src/components/display/DisplayRestoreErrorBoundary.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DisplayRestoreErrorBoundary } from "./DisplayRestoreErrorBoundary";
+
+const { dismissRestore, logError } = vi.hoisted(() => ({
+  dismissRestore: vi.fn().mockResolvedValue(undefined),
+  logError: vi.fn(),
+}));
+
+vi.mock("../../stores", () => ({
+  useDisplayStore: {
+    getState: () => ({ dismissRestore }),
+  },
+}));
+
+vi.mock("../../services/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: logError,
+  }),
+}));
+
+function Boom(): never {
+  throw new Error("render boom");
+}
+
+describe("DisplayRestoreErrorBoundary", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dismissRestore.mockReset().mockResolvedValue(undefined);
+    logError.mockReset();
+    // React logs caught errors to console.error; silence it in this test
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("renders children when no error", () => {
+    render(
+      <DisplayRestoreErrorBoundary>
+        <div>healthy child</div>
+      </DisplayRestoreErrorBoundary>,
+    );
+    expect(screen.getByText("healthy child")).toBeInTheDocument();
+  });
+
+  it("renders accessible fallback UI when a child throws", () => {
+    render(
+      <DisplayRestoreErrorBoundary>
+        <Boom />
+      </DisplayRestoreErrorBoundary>,
+    );
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toBeInTheDocument();
+    // aria-labelledby and aria-describedby point at rendered ids
+    const title = screen.getByText("Couldn't restore display layout");
+    expect(dialog.getAttribute("aria-labelledby")).toBe(title.id);
+    expect(dialog.getAttribute("aria-describedby")).toBeTruthy();
+    expect(document.getElementById(dialog.getAttribute("aria-describedby")!)).toBeInTheDocument();
+  });
+
+  it("logs the captured error via componentDidCatch", () => {
+    render(
+      <DisplayRestoreErrorBoundary>
+        <Boom />
+      </DisplayRestoreErrorBoundary>,
+    );
+    expect(logError).toHaveBeenCalledWith(
+      "DisplayRestoreDialog crashed",
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+  });
+
+  it("autofocuses the Dismiss button when the fallback opens", () => {
+    render(
+      <DisplayRestoreErrorBoundary>
+        <Boom />
+      </DisplayRestoreErrorBoundary>,
+    );
+    expect(screen.getByRole("button", { name: "Dismiss" })).toHaveFocus();
+  });
+
+  it("dismisses the pending restore when Dismiss is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <DisplayRestoreErrorBoundary>
+        <Boom />
+      </DisplayRestoreErrorBoundary>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(dismissRestore).toHaveBeenCalledTimes(1);
+  });
+
+  it("also dismisses when the Close (X) button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <DisplayRestoreErrorBoundary>
+        <Boom />
+      </DisplayRestoreErrorBoundary>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(dismissRestore).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses on Escape", async () => {
+    const user = userEvent.setup();
+    render(
+      <DisplayRestoreErrorBoundary>
+        <Boom />
+      </DisplayRestoreErrorBoundary>,
+    );
+
+    await user.keyboard("{Escape}");
+    expect(dismissRestore).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and recovers when dismissRestore rejects", async () => {
+    dismissRestore.mockRejectedValueOnce(new Error("store boom"));
+    const user = userEvent.setup();
+
+    render(
+      <DisplayRestoreErrorBoundary>
+        <Boom />
+      </DisplayRestoreErrorBoundary>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(dismissRestore).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith(
+      "dismissRestore failed during error recovery:",
+      expect.any(Error),
+    );
+  });
+});

--- a/src/components/display/DisplayRestoreErrorBoundary.tsx
+++ b/src/components/display/DisplayRestoreErrorBoundary.tsx
@@ -1,0 +1,103 @@
+import { Component, createRef, type ErrorInfo, type ReactNode } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import { createLogger } from "../../services/logger";
+import { useDisplayStore } from "../../stores";
+
+const log = createLogger("DisplayRestoreDialog");
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  readonly error: Error | null;
+}
+
+export class DisplayRestoreErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  private dismissButtonRef = createRef<HTMLButtonElement>();
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    log.error("DisplayRestoreDialog crashed", { error, componentStack: info.componentStack });
+  }
+
+  componentDidMount(): void {
+    if (this.state.error) this.dismissButtonRef.current?.focus();
+  }
+
+  componentDidUpdate(_: Props, prevState: State): void {
+    if (!prevState.error && this.state.error) {
+      this.dismissButtonRef.current?.focus();
+    }
+  }
+
+  private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key === "Escape") void this.handleDismiss();
+  };
+
+  private handleDismiss = async (): Promise<void> => {
+    // Drop the pending restore so the dialog won't re-mount and re-throw,
+    // then clear the boundary so the app continues without it.
+    try {
+      await useDisplayStore.getState().dismissRestore();
+    } catch (err) {
+      log.error("dismissRestore failed during error recovery:", err);
+    }
+    try {
+      this.setState({ error: null });
+    } catch (err) {
+      log.error("Failed to clear error boundary state:", err);
+    }
+  };
+
+  render(): ReactNode {
+    if (!this.state.error) return this.props.children;
+
+    return (
+      <div
+        role="alertdialog"
+        aria-labelledby="display-restore-error-title"
+        aria-describedby="display-restore-error-body"
+        onKeyDown={this.handleKeyDown}
+        className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      >
+        <div className="bg-gray-800 rounded-lg p-4 w-96 shadow-xl border border-gray-700">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <AlertTriangle size={20} className="text-amber-400" />
+              <h3 id="display-restore-error-title" className="text-lg font-medium text-white">
+                Couldn't restore display layout
+              </h3>
+            </div>
+            <button
+              onClick={this.handleDismiss}
+              className="text-gray-400 hover:text-white transition-colors"
+              title="Close"
+              aria-label="Close"
+            >
+              <X size={20} />
+            </button>
+          </div>
+          <p id="display-restore-error-body" className="text-gray-300 text-sm mb-4">
+            Something went wrong while showing the layout restore prompt. You can keep using the app
+            and arrange your windows manually.
+          </p>
+          <div className="flex justify-end border-t border-gray-700 pt-4">
+            <button
+              ref={this.dismissButtonRef}
+              onClick={this.handleDismiss}
+              className="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/display/index.ts
+++ b/src/components/display/index.ts
@@ -1,1 +1,2 @@
 export { DisplayRestoreDialog } from "./DisplayRestoreDialog";
+export { DisplayRestoreErrorBoundary } from "./DisplayRestoreErrorBoundary";


### PR DESCRIPTION
Closes #56.

## Summary
- New `DisplayRestoreErrorBoundary` (class component) wrapping `DisplayRestoreDialog` in `App.tsx`.
- On a child render error, the boundary shows a fallback `role="alertdialog"` with three dismiss paths: Esc, the X button, and a primary "Dismiss" button (autofocused on open).
- Dismissing calls `useDisplayStore.getState().dismissRestore()` and clears the boundary, so the underlying broken state is purged and the dialog won't immediately re-mount and re-throw.
- `componentDidCatch` logs `"DisplayRestoreDialog crashed"` via `createLogger("DisplayRestoreDialog")` with the error and component stack.

## Implementation notes
- Both async-failure points (`dismissRestore()` and `setState`) are wrapped in independent try/catch blocks so a throw in either cannot escape as an unhandled promise rejection.
- ESC handler does not call `stopPropagation` — sibling modals and global ESC listeners still see the event.
- `aria-labelledby` / `aria-describedby` wired to rendered ids.

## Test plan
- [x] `just check` clean
- [x] `just test` — 685/685 (8 new boundary tests covering: passthrough, fallback render + aria wiring, logger invocation, autofocus, Dismiss click, Close (X) click, Escape, dismissRestore rejection)
- [ ] Manual smoke: trigger a render error inside `DisplayRestoreDialog` (e.g. temporarily throw in the body), verify fallback renders, Esc/X/Dismiss all close it, app stays usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)